### PR TITLE
Integrate Currency Code Property

### DIFF
--- a/Gasoline.xcodeproj/project.pbxproj
+++ b/Gasoline.xcodeproj/project.pbxproj
@@ -16,6 +16,7 @@
 		B92E57AE1F096290003437B3 /* DataBase.swift in Sources */ = {isa = PBXBuildFile; fileRef = B92E57AD1F096290003437B3 /* DataBase.swift */; };
 		B9302F551BAB6F5B00CE9CC4 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B9302F541BAB6F5B00CE9CC4 /* Assets.xcassets */; };
 		B936F8EE1C7A327C008C66E5 /* Constants.swift in Sources */ = {isa = PBXBuildFile; fileRef = B936F8ED1C7A327C008C66E5 /* Constants.swift */; };
+		B95610931F12830D000E5649 /* MeasurementFormatHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = B95610921F1282C9000E5649 /* MeasurementFormatHandler.swift */; };
 		B973FEA91F094C47008D368E /* RootViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B973FEA81F094C47008D368E /* RootViewController.swift */; };
 		B973FEAB1F094D34008D368E /* RefuelListViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B973FEAA1F094D34008D368E /* RefuelListViewController.swift */; };
 		B973FEAD1F094E2E008D368E /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = B973FEAC1F094E2E008D368E /* Extensions.swift */; };
@@ -40,6 +41,7 @@
 		B9302F541BAB6F5B00CE9CC4 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		B9302F591BAB6F5B00CE9CC4 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		B936F8ED1C7A327C008C66E5 /* Constants.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
+		B95610921F1282C9000E5649 /* MeasurementFormatHandler.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MeasurementFormatHandler.swift; sourceTree = "<group>"; };
 		B973FEA81F094C47008D368E /* RootViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RootViewController.swift; sourceTree = "<group>"; };
 		B973FEAA1F094D34008D368E /* RefuelListViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = RefuelListViewController.swift; sourceTree = "<group>"; };
 		B973FEAC1F094E2E008D368E /* Extensions.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Extensions.swift; sourceTree = "<group>"; };
@@ -122,7 +124,6 @@
 			children = (
 				B911C7A81BDC5A4900016B85 /* AppDelegate.swift */,
 				B936F8ED1C7A327C008C66E5 /* Constants.swift */,
-				B9DD14621F0997580095AD0F /* CurrencyFormatter.swift */,
 				B92E57AD1F096290003437B3 /* DataBase.swift */,
 				B973FEAC1F094E2E008D368E /* Extensions.swift */,
 				B973FEAE1F094EE5008D368E /* GenericDataSource.swift */,
@@ -130,6 +131,7 @@
 				B973FEAA1F094D34008D368E /* RefuelListViewController.swift */,
 				B973FEA81F094C47008D368E /* RootViewController.swift */,
 				B95450D01F12754800371C0F /* cells */,
+				B95610941F128400000E5649 /* formatter */,
 				B92B622D1C8F573D00790D3B /* model */,
 				B92B622E1C8F576600790D3B /* Supporting Files */,
 			);
@@ -143,6 +145,15 @@
 				B90B921C1C976B2F0049C7A8 /* TextFieldCell.swift */,
 			);
 			path = cells;
+			sourceTree = "<group>";
+		};
+		B95610941F128400000E5649 /* formatter */ = {
+			isa = PBXGroup;
+			children = (
+				B9DD14621F0997580095AD0F /* CurrencyFormatter.swift */,
+				B95610921F1282C9000E5649 /* MeasurementFormatHandler.swift */,
+			);
+			path = formatter;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -270,6 +281,7 @@
 			files = (
 				B911C7A91BDC5A4900016B85 /* AppDelegate.swift in Sources */,
 				B973FEAF1F094EE5008D368E /* GenericDataSource.swift in Sources */,
+				B95610931F12830D000E5649 /* MeasurementFormatHandler.swift in Sources */,
 				B92E57AE1F096290003437B3 /* DataBase.swift in Sources */,
 				B973FEA91F094C47008D368E /* RootViewController.swift in Sources */,
 				B9DD14631F0997580095AD0F /* CurrencyFormatter.swift in Sources */,

--- a/Gasoline/AppDelegate.swift
+++ b/Gasoline/AppDelegate.swift
@@ -28,7 +28,7 @@
 
 import UIKit
 
-var globalDataBaseReference: DataBase = DataBaseImplementation.sharedInstance
+var globalDataBaseReference: DataBase = DataBaseImplementation.shared
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {

--- a/Gasoline/DataBase.swift
+++ b/Gasoline/DataBase.swift
@@ -11,7 +11,7 @@ import Foundation
 protocol DataBase {
 
     // Singleton
-    static var sharedInstance: DataBase {get}
+    static var shared: DataBase {get}
 
     func query<T>(completion: ((_ items: [T]) -> Void))
     mutating func add(item: Any, completion: (() -> ()))
@@ -20,7 +20,7 @@ protocol DataBase {
 struct DataBaseImplementation: DataBase {
 
     // Singleton
-    static let sharedInstance: DataBase = DataBaseImplementation()
+    static let shared: DataBase = DataBaseImplementation()
     private init() {}
 
     private var store: [Any] = {

--- a/Gasoline/Refuel.swift
+++ b/Gasoline/Refuel.swift
@@ -15,6 +15,7 @@ public struct Refuel: Codable {
         case createdAt = "created_at"
 
         case date
+        case currencyCode = "currency_code"
         case literPrice = "liter_price"
         case fuelAmount = "fuel_amount"
         case mileage
@@ -31,11 +32,13 @@ public struct Refuel: Codable {
     public var totalCosts: Double { return literPrice * fuelAmount.value }
     /// The date the refuel action has been done
     public let date: Date
+    /// The currency that applies to all price values of this class.
+    public let currencyCode: String
     /// The price per liter in the major curency value (Euro, Dollar, ...)
     public let literPrice: Double
     /// The taken fuel amount im milli liters
     public let fuelAmount: Measurement<UnitVolume>
-    /// The current mileage directly before the refuel
+    /// The current mileage right at the gas station
     public let mileage: Measurement<UnitLength>
     /// An optional note from the user
     public let note: String?
@@ -43,12 +46,18 @@ public struct Refuel: Codable {
 
 extension Refuel {
 
-    init(date: Date, literPrice: Double, fuelAmount: Measurement<UnitVolume>, mileage: Measurement<UnitLength>, note: String? = nil) {
+    init(
+        date: Date,
+        currencyCode: String = "EUR", // TODO: The default for now - change later!
+        literPrice: Double,
+        fuelAmount: Measurement<UnitVolume>,
+        mileage: Measurement<UnitLength>, note: String? = nil) {
 
         self.init(
             id: NSUUID().uuidString,
             createdAt: Date(),
             date: date,
+            currencyCode: currencyCode,
             literPrice: literPrice,
             fuelAmount: fuelAmount,
             mileage: mileage,

--- a/Gasoline/cells/RefuelCell.swift
+++ b/Gasoline/cells/RefuelCell.swift
@@ -44,7 +44,6 @@ class RefuelCell: UITableViewCell {
         requiredCompressionResistancyForAxis: [UILayoutConstraintAxis] = []) -> UILabel {
 
         let label = UILabel()
-        label.backgroundColor = .red
         label.textAlignment = textAlignment
         requiredCompressionResistancyForAxis.forEach { label.setContentCompressionResistancePriority(.required, for: $0) }
         return label
@@ -58,20 +57,16 @@ extension RefuelCell: ConfigurableCell {
         guard let item = item as? Refuel else { return }
 
         let date = SHDateFormatter.shared.stringFromDate(date: item.date, format: .noTimeShortDate)
-        let mileage = MeasurementFormatHandler.shared.stringFrom(measurement: item.mileage, maximumFractionDigits: 0)
-        let fuelAmount = MeasurementFormatHandler.shared.stringFrom(measurement: item.mileage, maximumFractionDigits: 2)
         let time = SHDateFormatter.shared.stringFromDate(date: item.date, format: .shortTimeNoDate)
-        let totalPrice = CurrencyFormatter.shared.stringFromValue(value: item.totalCosts, currencyCode: item.currencyCode)
-        let literPrice = CurrencyFormatter.shared.stringFromValue(
+
+        dateLabel.text = "\(date), \(time)"
+        mileageLabel.text = MeasurementFormatHandler.shared.stringFrom(measurement: item.mileage, maximumFractionDigits: 0)
+        fuelAmountLabel.text = MeasurementFormatHandler.shared.stringFrom(measurement: item.fuelAmount, maximumFractionDigits: 2)
+        notesLabel.text = item.note ?? ""
+        totalPriceLabel.text = CurrencyFormatter.shared.stringFromValue(value: item.totalCosts, currencyCode: item.currencyCode)
+        literPriceLabel.text = CurrencyFormatter.shared.stringFromValue(
             value: item.literPrice,
             currencyCode: item.currencyCode,
             maximumFractionDigits: 3)
-
-        dateLabel.text = "\(date), \(time)"
-        mileageLabel.text = mileage
-        fuelAmountLabel.text = fuelAmount
-        literPriceLabel.text = literPrice
-        totalPriceLabel.text = totalPrice
-        notesLabel.text = item.note ?? ""
     }
 }

--- a/Gasoline/cells/RefuelCell.swift
+++ b/Gasoline/cells/RefuelCell.swift
@@ -58,15 +58,20 @@ extension RefuelCell: ConfigurableCell {
         guard let item = item as? Refuel else { return }
 
         let date = SHDateFormatter.shared.stringFromDate(date: item.date, format: .noTimeShortDate)
+        let mileage = MeasurementFormatHandler.shared.stringFrom(measurement: item.mileage, maximumFractionDigits: 0)
+        let fuelAmount = MeasurementFormatHandler.shared.stringFrom(measurement: item.mileage, maximumFractionDigits: 2)
         let time = SHDateFormatter.shared.stringFromDate(date: item.date, format: .shortTimeNoDate)
-        let literPrice = CurrencyFormatter.shared.stringFromValue(value: item.literPrice, maximumFractionDigits: 3)
-        let totalPrice = CurrencyFormatter.shared.stringFromValue(value: item.totalCosts)
+        let totalPrice = CurrencyFormatter.shared.stringFromValue(value: item.totalCosts, currencyCode: item.currencyCode)
+        let literPrice = CurrencyFormatter.shared.stringFromValue(
+            value: item.literPrice,
+            currencyCode: item.currencyCode,
+            maximumFractionDigits: 3)
 
         dateLabel.text = "\(date), \(time)"
-        mileageLabel.text = "\(item.mileage)"
-        fuelAmountLabel.text = "\(item.fuelAmount)"
-        literPriceLabel.text = "\(literPrice)"
-        totalPriceLabel.text = "\(totalPrice)"
+        mileageLabel.text = mileage
+        fuelAmountLabel.text = fuelAmount
+        literPriceLabel.text = literPrice
+        totalPriceLabel.text = totalPrice
         notesLabel.text = item.note ?? ""
     }
 }

--- a/Gasoline/formatter/CurrencyFormatter.swift
+++ b/Gasoline/formatter/CurrencyFormatter.swift
@@ -22,6 +22,6 @@ public struct CurrencyFormatter {
     func stringFromValue(value: Double, currencyCode: String, maximumFractionDigits: Int = 2) -> String {
         formatter.maximumFractionDigits = maximumFractionDigits
         formatter.currencyCode = currencyCode
-        return formatter.string(from: NSNumber(floatLiteral: value)) ?? ""
+        return formatter.string(from: NSNumber(floatLiteral: value)) ?? "-,--"
     }
 }

--- a/Gasoline/formatter/CurrencyFormatter.swift
+++ b/Gasoline/formatter/CurrencyFormatter.swift
@@ -19,8 +19,9 @@ public struct CurrencyFormatter {
         return formatter
     }()
 
-    func stringFromValue(value: Double, maximumFractionDigits: Int = 2) -> String {
+    func stringFromValue(value: Double, currencyCode: String, maximumFractionDigits: Int = 2) -> String {
         formatter.maximumFractionDigits = maximumFractionDigits
+        formatter.currencyCode = currencyCode
         return formatter.string(from: NSNumber(floatLiteral: value)) ?? ""
     }
 }

--- a/Gasoline/formatter/MeasurementFormatHandler.swift
+++ b/Gasoline/formatter/MeasurementFormatHandler.swift
@@ -19,6 +19,7 @@ public struct MeasurementFormatHandler {
     }()
 
     func stringFrom<U>(measurement: Measurement<U>, maximumFractionDigits: Int) -> String {
+        formatter.numberFormatter.maximumFractionDigits = maximumFractionDigits
         return formatter.string(from: measurement)
     }
 }

--- a/Gasoline/formatter/MeasurementFormatHandler.swift
+++ b/Gasoline/formatter/MeasurementFormatHandler.swift
@@ -1,0 +1,24 @@
+//
+//  MeasurementFormatHandler.swift
+//  Gasoline
+//
+//  Created by Stefan Herold on 02.07.17.
+//  Copyright © 2017 Stefan Herold. All rights reserved.
+//
+
+import UIKit
+
+public struct MeasurementFormatHandler {
+
+    public static let shared = MeasurementFormatHandler()
+    private init() {}
+
+    private let formatter: MeasurementFormatter = {
+        let formatter = MeasurementFormatter()
+        return formatter
+    }()
+
+    func stringFrom<U>(measurement: Measurement<U>, maximumFractionDigits: Int) -> String {
+        return formatter.string(from: measurement)
+    }
+}


### PR DESCRIPTION
When prices are delivered to the backend it is important to store the used currency along the value. Without this it is not possible to display the value correctly later in different locales than the one used while creating the refuel.