### PR TITLE
Relative Dates on Dashboard

### DIFF
--- a/Gasoline/AppDelegate.swift
+++ b/Gasoline/AppDelegate.swift
@@ -7,14 +7,13 @@
 //
 
 // IMPROVEMENTS
-// TODO: Implement Adding!!!!!!!!!
-// TODO: Save the date with a standardized time 12:00 afternoon
+// TODO: Implement Adding
+// TODO: Implement Persistence
 // TODO: Use the decimal keypad and and include a accessory view on top with next prev buttons
 // TODO: Make fonts dark gray: 30, 60, ...
 // TODO: Realize Datepicker as seperate View and show it from below on button press.
 // TODO: Check the Date 22:00 after changing dateii
 // TODO: Integrate an advanced date formatter class and a relative date/time format on dashboard
-// TODO: Make a replacement for NSUsewrdefaults that stores all frefixes all keys (PLCDataPersistor)
 
 // FEATURES
 // TODO: Taking Picture of the bill

--- a/Gasoline/cells/RefuelCell.swift
+++ b/Gasoline/cells/RefuelCell.swift
@@ -56,7 +56,7 @@ extension RefuelCell: ConfigurableCell {
 
         guard let item = item as? Refuel else { return }
 
-        let date = SHDateFormatter.shared.stringFromDate(date: item.date, format: .noTimeShortDate)
+        let date = SHDateFormatter.shared.stringFromDate(date: item.date, format: .noTimeRelativeDate)
         let time = SHDateFormatter.shared.stringFromDate(date: item.date, format: .shortTimeNoDate)
 
         dateLabel.text = "\(date), \(time)"


### PR DESCRIPTION
The cells on dashboards now use relative dates and a short version of a date when the day is not today or yesterday.